### PR TITLE
`SafeCollectionAccess` + `StringIntegerAccess` == `SafeStringIntegerAccess`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+
+Package.resolved

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "container:../..">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -5,19 +5,33 @@ import PackageDescription
 
 let package = Package(
     name: "StringIntegerAccess",
+    
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "StringIntegerAccess",
             targets: ["StringIntegerAccess"]),
+        .library(
+            name: "SafeStringIntegerAccess",
+            targets: ["SafeStringIntegerAccess"]),
     ],
+    
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(name: "SafeCollectionAccess", url: "https://github.com/RougeWare/Swift-Safe-Collection-Access.git", from: "2.1.0")
     ],
+    
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        
+        .target(
+            name: "SafeStringIntegerAccess",
+            dependencies: ["StringIntegerAccess", "SafeCollectionAccess"]),
+        .testTarget(
+            name: "SafeStringIntegerAccessTests",
+            dependencies: ["SafeStringIntegerAccess"]),
+        
         .target(
             name: "StringIntegerAccess",
             dependencies: []),

--- a/README.md
+++ b/README.md
@@ -9,8 +9,29 @@ someString[someString.index(someString.startIndex, offsetBy: 2) ... someString.i
 to this:
 
 ```swift
+import StringIntegerAccess
+
 someString[2...5]
 ```
+
+
+## Safety ##
+
+If you prefer, you can also have the peace-of-mind that whatever integers you pass, it won't crash! Starting in version `1.3.0`, you can now use `[orNil:]` subscripts, which will return the same values as the regular ones, but if you give them out-of-range indices, they return `nil` instead of crashing: 
+
+```
+import SafeStringIntegerAccess
+
+let someString = "Hello, World!"
+
+someString[orNil: 3..<5] == "lo"
+someString[orNil: 3..<5] == someString[3..<5]
+someString[orNil: 42..<99] == nil 
+someString[orNil: -10 ..< -5] == nil 
+```
+
+Even better, this also implicitly imports `StringIntegerAccess`, so you don't have to double-up the imports!
+
 
 ## Performance ##
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ someString[2...5]
 
 ## Safety ##
 
-If you prefer, you can also have the peace-of-mind that whatever integers you pass, it won't crash! Starting in version `1.3.0`, you can now use `[orNil:]` subscripts, which will return the same values as the regular ones, but if you give them out-of-range indices, they return `nil` instead of crashing: 
+If you prefer, you can also have the peace-of-mind that whatever integers you pass, it won't crash! Starting in version `2.0.0`, you can now use `[orNil:]` subscripts, which will return the same values as the regular ones, but if you give them out-of-range indices, they return `nil` instead of crashing: 
 
-```
+```swift
 import SafeStringIntegerAccess
 
 let someString = "Hello, World!"

--- a/Sources/SafeStringIntegerAccess/StringIntegerAccess + SafeCollectionAccess.swift
+++ b/Sources/SafeStringIntegerAccess/StringIntegerAccess + SafeCollectionAccess.swift
@@ -1,0 +1,366 @@
+//
+//  StringIntegerAccess + SafeCollectionAccess.swift
+//  String Integer Access
+//
+//  Created by Ben Leggiero on 2020-05-20.
+//  Copyright © 2020 Ben Leggiero. All rights reserved.
+//
+
+import SafeCollectionAccess
+import StringIntegerAccess
+
+
+
+public extension StringProtocol
+    where Self: RandomAccessCollection
+{
+    /// Determines whether this collection has an item at the given character index
+    ///
+    /// - Parameter characterIndex: An index which might be in this string
+    /// - Returns: `true` iff `index` points to a character that’s in this string
+    func contains(index characterIndex: Int) -> Bool {
+        self.index(orNil: characterIndex).map(self.contains(index:)) ?? false
+    }
+    
+    
+    /// A non-crashing form of `myString.index(characterOffset)`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString.index(7)
+    /// myString.index(orNil: 7)
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString.index(42) // crashes
+    /// myString.index(orNil: 42) // returns nil
+    /// ```
+    ///
+    /// - Parameter characterOffset: The index of a character in this string, as an offset from the first index
+    /// - Returns: An index offset by `characterIndex` from the start of the string, or `nil` if that's outside this string
+    @inlinable
+    func index(orNil characterOffset: Int) -> Index? {
+        guard
+            characterOffset >= 0,
+            characterOffset < count
+            else
+        {
+            return nil
+        }
+        
+        let prospective = self.index(startIndex, offsetBy: characterOffset)
+        
+        return self.indices.contains(prospective)
+            ? prospective
+            : nil
+    }
+    
+    
+    /// A non-crashing form of `myString.index(beforeOrNil: characterIndex)`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString.index(before: myString.index(myString.startIndex, offsetBy: 2))
+    /// myString.index(beforeOrNil: 2)
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString.index(before: 42) // crashes
+    /// myString.index(beforeOrNil: 42) // returns nil
+    /// ```
+    ///
+    /// - Parameter characterOffset: The index after a character in this string, as an offset from the first index
+    /// - Returns: An index offset by `characterIndex` from the start of the string, or `nil` if the index is out of the string
+    @inlinable
+    func index(beforeOrNil characterOffset: Int) -> Index? {
+        guard
+            characterOffset > 0,
+            characterOffset <= count
+            else
+        {
+            // Looking for the index before the given one, so less than the min index (0) is invalid, as is greater
+            // than greatest index + 1 (count)
+            return nil
+        }
+        
+        let prospective = self.index(before: self.index(startIndex, offsetBy: characterOffset))
+        
+        return self.indices.contains(prospective) // Sanity check
+            ? prospective
+            : nil
+    }
+    
+    
+    /// A non-crashing form of `myString[characterIndex]`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString[orNil: myString.index(myString.startIndex, offsetBy: 2)]
+    /// myString[orNil: 2]
+    /// ```
+    ///
+    /// However, this version doesn't require as much boilerplate and won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString[myString.index(myString.startIndex, offsetBy: 42)] // crashes
+    /// myString.index(orNil: 42).compactMap { myString[orNil: $0] } // nil
+    /// myString[42] // crashes
+    /// myString[orNil: 42] // returns nil
+    /// ```
+    ///
+    /// - Parameter characterIndex: A valid index of a character in the string. Must be greater than or equal to `0`
+    ///                             and less than `count`.
+    /// - Returns: The character at the given index in this string, or `nil` if the index is out of the string
+    @inlinable
+    subscript(orNil characterIndex: Int) -> Element? {
+        guard let index = self.index(orNil: characterIndex) else {
+            return nil
+        }
+        
+        return self[orNil: index]
+    }
+    
+    
+    /// A non-crashing form of `myString[lower...upper]`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString[myString.index(myString.startIndex, offsetBy: 3) ... myString.index(myString.startIndex, offsetBy: 4)]
+    /// myString[3...4]
+    /// myString[orNil: myString.index(myString.startIndex, offsetBy: 3) ... myString.index(myString.startIndex, offsetBy: 4)]
+    /// myString[orNil: 3...4]
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString[myString.index(myString.startIndex, offsetBy: 7) ... myString.index(myString.startIndex, offsetBy: 42)] // crashes
+    /// myString[7...42] // crashes
+    /// myString[orNil: 7...42] // returns nil
+    /// ```
+    ///
+    /// - Parameter range: A range of valid lower and upper indices of characters in the string. Must be contained
+    ///                    within `0` (inclusive) and `count` (exclusive).
+    /// - Returns: The characters at the given index-range in this string, or `nil` if either index is out of the string
+    @inlinable
+    subscript(orNil range: ClosedRange<Int>) -> SubSequence? {
+        guard
+            let lowerIndex = self.index(orNil: range.lowerBound),
+            let upperIndex = self.index(orNil: range.upperBound)
+            else
+        {
+            return nil
+        }
+        
+        return self[orNil: lowerIndex ... upperIndex]
+    }
+    
+    
+    /// A non-crashing form of `myString[lower..<upper]`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString[myString.index(myString.startIndex, offsetBy: 3) ..< myString.index(myString.startIndex, offsetBy: 5)]
+    /// myString[3..<5]
+    /// myString[orNil: myString.index(myString.startIndex, offsetBy: 3) ..< myString.index(myString.startIndex, offsetBy: 5)]
+    /// myString[orNil: 3..<5]
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString[myString.index(myString.startIndex, offsetBy: 7) ..< myString.index(myString.startIndex, offsetBy: 42)] // crashes
+    /// myString[7..<42] // crashes
+    /// myString[orNil: 7..<42] // returns nil
+    /// ```
+    ///
+    /// - Parameter range: A range of valid lower and upper indices of characters in the string. Must be contained
+    ///                    within `0` (inclusive) and `count` (inclusive).
+    /// - Returns: The characters at the given index-range in this string, or `nil` if either index is out of the string
+    @inlinable
+    subscript(orNil range: Range<Int>) -> SubSequence? {
+        
+        guard !range.isEmpty else {
+            // An empty range is the same as a character accessor at the lower bound, but returning a single-character
+            // Substring instead of a Character
+            
+            guard let lowerIndex = self.index(orNil: range.lowerBound) else {
+                // ... unless it's completely out of range, then just return `nil`
+                return nil
+            }
+            
+            return self[orNil: lowerIndex ..< lowerIndex]
+        }
+        
+        // Now that the single-character case is out of the way, get the lower and before-upper indices
+        
+        guard
+            let lowerIndex = self.index(orNil: range.lowerBound),
+            let beforeUpperIndex = self.index(beforeOrNil: range.upperBound)
+            else
+        {
+            return nil
+        }
+        
+        // self[m ..< n] == self[m ... n-1]
+        return self[orNil: lowerIndex ... beforeUpperIndex]
+    }
+    
+    
+    /// A non-crashing form of `myString[lower...]`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString[3...]
+    /// myString[orNil: 3...]
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString[myString.index(myString.startIndex, offsetBy: 7) ...] // crashes
+    /// myString[7...] // crashes
+    /// myString[orNil: 7...] // returns nil
+    /// ```
+    ///
+    /// - Parameter range: A range of a valid lower character index through the end of the string. Must be equal to or
+    ///                    greater than `0`
+    /// - Returns: The characters at the given index-range in this string, or `nil` if the index is out of the string
+    @inlinable
+    subscript(orNil range: PartialRangeFrom<Int>) -> SubSequence? {
+        
+        guard range.lowerBound != count else {
+            return self[endIndex...]
+        }
+        
+        guard let lowerIndex = self.index(orNil: range.lowerBound) else {
+            return nil
+        }
+        
+        return self[orNil: lowerIndex...]
+    }
+    
+    
+    /// A non-crashing form of `myString[..<lower]`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString[..<5]
+    /// myString[orNil: ..<5]
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString[..<myString.index(myString.startIndex, offsetBy: 42)] // crashes
+    /// myString[..<42] // crashes
+    /// myString[orNil: ..<42] // returns nil
+    /// ```
+    ///
+    /// - Parameter range: A range of the start of the string to a valid upper character index in the string. Must be
+    ///                    less than or equal to than `count`.
+    /// - Returns: The characters at the given index-range in this string, or `nil` if the index is out of the string
+    @inlinable
+    subscript(orNil range: PartialRangeUpTo<Int>) -> SubSequence? {
+        
+        guard range.upperBound != count else {
+            // self[orNil: ..<self.count] == self[..<self.count] == self[...]
+            return self[...]
+        }
+        
+        guard let upperIndex = self.index(orNil: range.upperBound) else {
+            return nil
+        }
+        
+        return self[orNil: ..<upperIndex]
+    }
+    
+    
+    /// A non-crashing form of `myString[..<lower]`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString[...4]
+    /// myString[orNil: ...4]
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString[...myString.index(myString.startIndex, offsetBy: 42)] // crashes
+    /// myString[...42] // crashes
+    /// myString[orNil: ...42] // returns nil
+    /// ```
+    ///
+    /// - Parameter range: A range of the start of the string through a valid upper character index in the string. Must
+    ///                    be less than to than `count`.
+    /// - Returns: The characters at the given index-range in this string, or `nil` if the index is out of the string
+    @inlinable
+    subscript(orNil range: PartialRangeThrough<Int>) -> SubSequence? {
+        guard let upperIndex = self.index(orNil: range.upperBound) else {
+            return nil
+        }
+        
+        return self[orNil: ...upperIndex]
+    }
+}
+
+
+
+#if canImport(ObjectiveC) // NSRange seems to only exist on platforms where there's Obj-C
+import Foundation
+
+
+
+public extension StringProtocol where Self: RandomAccessCollection {
+    
+    /// A non-crashing form of `myString[NSRange(location: lowerCharacterIndex, length: numberOfCharacters)]`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// let myString = "Hello, World!"
+    /// myString[NSRange(location: 3, length: 2)]
+    /// myString[orNil: NSRange(location: 3, length: 2)]
+    /// ```
+    ///
+    /// However, this version won't crash:
+    /// ```
+    /// let myString = ";)"
+    /// myString[NSRange(location: 42, length: 7)] // crashes
+    /// myString[orNil: NSRange(location: 42, length: 7)] // nil
+    /// ```
+    ///
+    /// - Parameter range: A range of valid indices of characters in the string. `location` must be less than `count`
+    ///                    (exclusive), and `length` must be less than `count` (inclusive). If `length` is longer than
+    ///                    `count`, or if `location` pushes the upper bound outside this string, or if `length` is
+    ///                    negative, this returns `nil`.
+    /// - Returns: The characters at the given index-range in this string, or `nil` if the index is out of the string
+    @inlinable
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    subscript(orNil range: NSRange) -> SubSequence? {
+        guard
+            range.length >= 0,
+            contains(index: range.lowerBound),
+            contains(index: range.upperBound)
+                || range.upperBound == count
+            else
+        {
+            return nil
+        }
+        
+        return self[range]
+    }
+}
+#endif

--- a/Sources/StringIntegerAccess/String + Integer access.swift
+++ b/Sources/StringIntegerAccess/String + Integer access.swift
@@ -26,6 +26,22 @@ public extension StringProtocol {
     }
     
     
+    /// Simple sugar for `myString.index(before: myString.index(myString.startIndex, offsetBy: characterIndex))`
+    ///
+    /// These are equivalent:
+    /// ```
+    /// myString.index(before: myString.index(myString.startIndex, offsetBy: characterIndex))
+    /// myString.index(before: characterIndex)
+    /// ```
+    ///
+    /// - Parameter characterOffset: The index after a character in this string, as an offset from the first index
+    /// - Returns: An index offset by `characterIndex` from the start of the string
+    @inline(__always)
+    func index(before characterOffset: Int) -> Index {
+        self.index(before: self.index(characterOffset))
+    }
+    
+    
     /// Simply sugar for `myString[myString.index(myString.startIndex, offsetBy: characterIndex)]`
     ///
     /// These are equivalent:
@@ -141,31 +157,26 @@ public extension StringProtocol {
     ///
     /// These are equivalent:
     /// ```
-    /// let mySubstring: Substring?
-    /// if range.length >= 0,
-    ///     let range = Range(nsRange, in: myString)
-    /// {
-    ///     mySubstring = myString[range]
-    /// }
-    /// else {
-    ///     mySubstring = nil
-    /// }
-    /// ```
-    /// ```
-    /// let mySubstring = myString[nsRange]
+    /// myString[myString.index(myString.startIndex, offsetBy: nsRange.lowerBound) ..< myString.index(myString.startIndex, offsetBy: nsRange.upperBound)]
+    /// myString[nsRange]
     /// ```
     ///
     /// - Parameter range: A range of valid indices of characters in the string. `location` must be less than `count`
     ///                    (exclusive), and `length` must be less than `count` (inclusive). If `length` is longer than
     ///                    `count`, or if `location` pushes the upper bound outside this string, or if `length` is
-    ///                    negative, this returns `nil`.
+    ///                    negative, this crashes.
     /// - Returns: The characters at the given index-range in this string
     @inlinable
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    subscript(_ range: NSRange) -> SubSequence? {
-        return range.length < 0
-            ? nil
-            : Range(range, in: self).map { self[$0] }
+    subscript(_ range: NSRange) -> SubSequence {
+        return self[range.lowerBound ..< range.upperBound]
     }
 }
 #endif
+
+
+
+// MARK: - Conformance to RandomAccessCollection
+
+extension String: RandomAccessCollection {}
+extension Substring: RandomAccessCollection {}

--- a/Tests/SafeStringIntegerAccessTests/SafeStringIntegerAccessTests.swift
+++ b/Tests/SafeStringIntegerAccessTests/SafeStringIntegerAccessTests.swift
@@ -1,0 +1,222 @@
+//
+//  SafeStringIntegerAccessTests.swift
+//  String Integer Access
+//
+//  Created by Ben Leggiero on 2020-05-21.
+//  Copyright © 2020 Ben Leggiero. All rights reserved.
+//
+
+import XCTest
+import SafeStringIntegerAccess
+
+
+
+final class SafeStringIntegerAccessTests: XCTestCase {
+    
+    func testContainsIndexOrNil() {
+        XCTAssertTrue("Hello".contains(index: 0))
+        XCTAssertTrue("Hello".contains(index: 1))
+        XCTAssertTrue("Hello".contains(index: 2))
+        XCTAssertTrue("Hello".contains(index: 3))
+        XCTAssertTrue("Hello".contains(index: 4))
+        
+        XCTAssertFalse("Hello".contains(index:  5))
+        XCTAssertFalse("Hello".contains(index:  99))
+        XCTAssertFalse("Hello".contains(index: -1))
+        XCTAssertFalse("Hello".contains(index: -99))
+    }
+    
+    
+    func testGetCharacterWithIntSubscriptOrNil() {
+        XCTAssertEqual("Hello, World!"[orNil: 0], "Hello, World!"[0]) // This just checks that importing `SafeStringIntegerAccess` also implicitly imports `stringIntegerAccess`
+        XCTAssertEqual("Hello, World!"[orNil: 0], "H")
+        XCTAssertEqual("Hello, World!"[orNil: 1], "e")
+        XCTAssertEqual("Hello, World!"[orNil: 12], "!")
+        XCTAssertEqual("Hello, World!"[orNil: 11], "d")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: 6], "🇺🇸")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 15], "👨‍👨‍👦‍👦")
+        
+        XCTAssertNil("Hello, World!"[orNil: -1])
+        XCTAssertNil("Hello, World!"[orNil: 13])
+        XCTAssertNil("Hello, World!"[orNil: -99])
+        XCTAssertNil("Hello, World!"[orNil: 99])
+        
+        XCTAssertNil("Hello 🇺🇸 America"[orNil: 15])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 32])
+    }
+    
+    
+    func testGetSubstringWithIntClosedRangeSubscriptOrNil() {
+        XCTAssertEqual("Hello, World!"[orNil: 0...12], "Hello, World!")
+        XCTAssertEqual("Hello, World!"[orNil: 0...1], "He")
+        XCTAssertEqual("Hello, World!"[orNil: 1...5], "ello,")
+        XCTAssertEqual("Hello, World!"[orNil: 12...12], "!")
+        XCTAssertEqual("Hello, World!"[orNil: 11...12], "d!")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: 3...9], "lo 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: 0...14], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8...25], "family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 0...31], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        
+        XCTAssertNil("Hello, World!"[orNil: -1...12])
+        XCTAssertNil("Hello, World!"[orNil: 0...13])
+        XCTAssertNil("Hello, World!"[orNil: -99...12])
+        XCTAssertNil("Hello, World!"[orNil: 0...99])
+        XCTAssertNil("Hello, World!"[orNil: -99...99])
+        
+        XCTAssertNil("Hello 🇺🇸 America"[orNil: 4...15])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 0...32])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8...32])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: -1...8])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8...99])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 50...99])
+    }
+    
+    
+    func testGetSubstringWithIntRangeSubscriptOrNil() {
+        XCTAssertEqual("Hello, World!"[orNil: 0..<13], "Hello, World!")
+        XCTAssertEqual("Hello, World!"[orNil: 0..<1], "H")
+        XCTAssertEqual("Hello, World!"[orNil: 1..<5], "ello")
+        XCTAssertEqual("Hello, World!"[orNil: 5..<5], "")
+        XCTAssertEqual("Hello, World!"[orNil: 12..<12], "")
+        XCTAssertEqual("Hello, World!"[orNil: 11..<12], "d")
+        XCTAssertEqual("Hello, World!"[orNil: 11..<13], "d!")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: 3..<10], "lo 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: 0..<15], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8..<26], "family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 0..<32], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        
+        XCTAssertNil("Hello, World!"[orNil: -1..<13])
+        XCTAssertNil("Hello, World!"[orNil: 0..<14])
+        XCTAssertNil("Hello, World!"[orNil: -99..<12])
+        XCTAssertNil("Hello, World!"[orNil: 0..<99])
+        XCTAssertNil("Hello, World!"[orNil: -99..<99])
+        XCTAssertNil("Hello, World!"[orNil: -10 ..< -5])
+        
+        XCTAssertNil("Hello 🇺🇸 America"[orNil: 4..<16])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 0..<33])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8..<33])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: -1..<8])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8..<99])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 50..<99])
+    }
+    
+    
+    func testGetSubstringWithIntPartialRangeFromSubscriptOrNil() {
+        XCTAssertEqual("Hello, World!"[orNil: 0...], "Hello, World!")
+        XCTAssertEqual("Hello, World!"[orNil: 1...], "ello, World!")
+        XCTAssertEqual("Hello, World!"[orNil: 11...], "d!")
+        XCTAssertEqual("Hello, World!"[orNil: 11...], "Hello, World!"[11...])
+        XCTAssertEqual("Hello, World!"[orNil: 12...], "!")
+        XCTAssertEqual("Hello, World!"[orNil: 13...], "")
+        XCTAssertEqual("Hello, World!"[orNil: 13...], "Hello, World!"[13...])
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: 3...], "lo 🇺🇸 America")
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: 0...], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8...], "family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 0...], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        
+        XCTAssertNil("Hello, World!"[orNil: ( 99)...])
+        XCTAssertNil("Hello, World!"[orNil: ( 14)...])
+        XCTAssertNil("Hello, World!"[orNil: (-1 )...])
+        XCTAssertNil("Hello, World!"[orNil: (-99)...])
+        
+        XCTAssertNil("Hello 🇺🇸 America"[orNil: 16...])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: (33)...])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: (-1)...])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: (50)...])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: (99)...])
+    }
+    
+    
+    func testGetSubstringWithIntPartialRangeUpToSubscriptOrNil() {
+        XCTAssertEqual("Hello, World!"[orNil: ..<1], "H")
+        XCTAssertEqual("Hello, World!"[orNil: ..<5], "Hello")
+        XCTAssertEqual("Hello, World!"[orNil: ..<12], "Hello, World")
+        XCTAssertEqual("Hello, World!"[orNil: ..<12], "Hello, World")
+        XCTAssertEqual("Hello, World!"[orNil: ..<13], "Hello, World!")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: ..<10], "Hello 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: ..<15], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ..<26], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ..<32], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        
+        XCTAssertNil("Hello, World!"[orNil: ..<( 99)])
+        XCTAssertNil("Hello, World!"[orNil: ..<( 14)])
+        XCTAssertNil("Hello, World!"[orNil: ..<(-1 )])
+        XCTAssertNil("Hello, World!"[orNil: ..<(-99)])
+        
+        XCTAssertNil("Hello 🇺🇸 America"[orNil: ..<16])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ..<( 33)])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ..<(-1 )])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ..<( 99)])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ..<(-99)])
+    }
+    
+    
+    func testGetSubstringWithIntPartialRangeUpThroughSubscriptOrNil() {
+        XCTAssertEqual("Hello, World!"[orNil: ...1], "He")
+        XCTAssertEqual("Hello, World!"[orNil: ...5], "Hello,")
+        XCTAssertEqual("Hello, World!"[orNil: ...12], "Hello, World!")
+        XCTAssertEqual("Hello, World!"[orNil: ...12], "Hello, World!")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: ...9], "Hello 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: ...14], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ...25], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ...31], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        
+        XCTAssertNil("Hello, World!"[orNil: ...( 99)])
+        XCTAssertNil("Hello, World!"[orNil: ...( 13)])
+        XCTAssertNil("Hello, World!"[orNil: ...(-1 )])
+        XCTAssertNil("Hello, World!"[orNil: ...(-99)])
+        
+        XCTAssertNil("Hello 🇺🇸 America"[orNil: ...15])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ...( 32)])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ...(-1 )])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ...( 99)])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: ...(-99)])
+    }
+    
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testGetSubstringWithNSRangeSubscriptOrNil() {
+        XCTAssertEqual("Hello, World!"[orNil: NSRange(location: 0, length: 13)], "Hello, World!")
+        XCTAssertEqual("Hello, World!"[orNil: NSRange(location: 0, length: 1)], "H")
+        XCTAssertEqual("Hello, World!"[orNil: NSRange(location: 1, length: 4)], "ello")
+        XCTAssertEqual("Hello, World!"[orNil: NSRange(location: 12, length: 0)], "")
+        XCTAssertEqual("Hello, World!"[orNil: NSRange(location: 11, length: 1)], "d")
+        XCTAssertEqual("Hello, World!"[orNil: NSRange(location: 11, length: 2)], "d!")
+        XCTAssertEqual("Hello, World!"[orNil: NSRange()], "")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: NSRange(location: 3, length: 7)], "lo 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[orNil: NSRange(location: 0, length: 15)], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: NSRange(location: 8, length: 18)], "family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: NSRange(location: 0, length: 32)], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        
+        
+        XCTAssertNil("Hello, World!"[orNil: NSRange(location: 5, length: -5)])
+        XCTAssertNil("Hello, World!"[orNil: NSRange(location: 11, length: 999)])
+        
+        XCTAssertNil("Hello 🇺🇸 America"[orNil: 4..<16])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 0..<33])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8..<33])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: -1..<8])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 8..<99])
+        XCTAssertNil("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[orNil: 50..<99])
+    }
+    
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    static var allTests = [
+        ("testContainsIndexOrNil", testContainsIndexOrNil),
+        ("testGetCharacterWithIntSubscriptOrNil", testGetCharacterWithIntSubscriptOrNil),
+        ("testGetSubstringWithIntClosedRangeSubscriptOrNil", testGetSubstringWithIntClosedRangeSubscriptOrNil),
+        ("testGetSubstringWithIntRangeSubscriptOrNil", testGetSubstringWithIntRangeSubscriptOrNil),
+        ("testGetSubstringWithIntPartialRangeFromSubscriptOrNil", testGetSubstringWithIntPartialRangeFromSubscriptOrNil),
+        ("testGetSubstringWithIntPartialRangeUpToSubscriptOrNil", testGetSubstringWithIntPartialRangeUpToSubscriptOrNil),
+        ("testGetSubstringWithIntPartialRangeUpThroughSubscriptOrNil", testGetSubstringWithIntPartialRangeUpThroughSubscriptOrNil),
+        ("testGetSubstringWithNSRangeSubscriptOrNil", testGetSubstringWithNSRangeSubscriptOrNil),
+    ]
+}

--- a/Tests/StringIntegerAccessTests/StringIntegerAccessTests.swift
+++ b/Tests/StringIntegerAccessTests/StringIntegerAccessTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import StringIntegerAccess
+import StringIntegerAccess
 
 
 
@@ -9,6 +9,9 @@ final class StringIntegerAccessTests: XCTestCase {
         XCTAssertEqual("Hello, World!"[1], "e")
         XCTAssertEqual("Hello, World!"[12], "!")
         XCTAssertEqual("Hello, World!"[11], "d")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[6], "🇺🇸")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[15], "👨‍👨‍👦‍👦")
     }
     
     
@@ -18,6 +21,11 @@ final class StringIntegerAccessTests: XCTestCase {
         XCTAssertEqual("Hello, World!"[1...5], "ello,")
         XCTAssertEqual("Hello, World!"[12...12], "!")
         XCTAssertEqual("Hello, World!"[11...12], "d!")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[3...9], "lo 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[0...14], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[8...25], "family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[0...31], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
     }
     
     
@@ -28,6 +36,11 @@ final class StringIntegerAccessTests: XCTestCase {
         XCTAssertEqual("Hello, World!"[12..<12], "")
         XCTAssertEqual("Hello, World!"[11..<12], "d")
         XCTAssertEqual("Hello, World!"[11..<13], "d!")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[3..<10], "lo 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[0..<15], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[8..<26], "family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[0..<32], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
     }
     
 
@@ -38,6 +51,11 @@ final class StringIntegerAccessTests: XCTestCase {
         XCTAssertEqual("Hello, World!"[11...], "d!")
         XCTAssertEqual("Hello, World!"[12...], "!")
         XCTAssertEqual("Hello, World!"[13...], "")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[3...], "lo 🇺🇸 America")
+        XCTAssertEqual("Hello 🇺🇸 America"[0...], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[8...], "family 👨‍👨‍👦‍👦 and apple pie 🥧")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[0...], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
     }
     
     
@@ -47,6 +65,11 @@ final class StringIntegerAccessTests: XCTestCase {
         XCTAssertEqual("Hello, World!"[..<12], "Hello, World")
         XCTAssertEqual("Hello, World!"[..<12], "Hello, World")
         XCTAssertEqual("Hello, World!"[..<13], "Hello, World!")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[..<10], "Hello 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[..<15], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[..<26], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[..<32], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
     }
     
     
@@ -55,6 +78,8 @@ final class StringIntegerAccessTests: XCTestCase {
         XCTAssertEqual("Hello, World!"[...5], "Hello,")
         XCTAssertEqual("Hello, World!"[...12], "Hello, World!")
         XCTAssertEqual("Hello, World!"[...12], "Hello, World!")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[...25], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[...31], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
     }
     
     
@@ -66,16 +91,23 @@ final class StringIntegerAccessTests: XCTestCase {
         XCTAssertEqual("Hello, World!"[NSRange(location: 12, length: 0)], "")
         XCTAssertEqual("Hello, World!"[NSRange(location: 11, length: 1)], "d")
         XCTAssertEqual("Hello, World!"[NSRange(location: 11, length: 2)], "d!")
-        XCTAssertNil("Hello, World!"[NSRange(location: 5, length: -5)])
-        XCTAssertNil("Hello, World!"[NSRange(location: 11, length: 999)])
+        XCTAssertEqual("Hello, World!"[NSRange()], "")
+        
+        XCTAssertEqual("Hello 🇺🇸 America"[NSRange(location: 3, length: 7)], "lo 🇺🇸 Am")
+        XCTAssertEqual("Hello 🇺🇸 America"[NSRange(location: 0, length: 15)], "Hello 🇺🇸 America")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[NSRange(location: 8, length: 18)], "family 👨‍👨‍👦‍👦 and apple")
+        XCTAssertEqual("Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧"[NSRange(location: 0, length: 32)], "Faith 🛐 family 👨‍👨‍👦‍👦 and apple pie 🥧")
     }
     
 
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     static var allTests = [
         ("testGetCharacterWithIntSubscript", testGetCharacterWithIntSubscript),
         ("testGetSubstringWithIntClosedRangeSubscript", testGetSubstringWithIntClosedRangeSubscript),
         ("testGetSubstringWithIntRangeSubscript", testGetSubstringWithIntRangeSubscript),
         ("testGetSubstringWithIntPartialRangeFromSubscript", testGetSubstringWithIntPartialRangeFromSubscript),
+        ("testGetSubstringWithIntPartialRangeUpToSubscript", testGetSubstringWithIntPartialRangeUpToSubscript),
         ("testGetSubstringWithIntPartialRangeUpThroughSubscript", testGetSubstringWithIntPartialRangeUpThroughSubscript),
+        ("testGetSubstringWithNSRangeSubscript", testGetSubstringWithNSRangeSubscript),
     ]
 }


### PR DESCRIPTION
Created a new library in this package which makes it safe to access strings with integers!

Also fixed a bug with `NSRange` subscripts (and made their return non-optional - MAJOR version bump?), and added emoji-infused tests to non-safe test suite
